### PR TITLE
Modified Get-Item example in New-ExplicitItemSource

### DIFF
--- a/appendix/packaging/new-explicititemsource.md
+++ b/appendix/packaging/new-explicititemsource.md
@@ -119,7 +119,7 @@ $package.Metadata.Version = "1.0";
 $package.Metadata.Readme = 'This text will be visible to people installing your package'
 
 # Add content/home and all of its children to the package
-$source = Get-Item 'master:\content\home' | New-ExplicitItemSource -Name 'Home Page' -InstallMode Overwrite
+$source = Get-Item 'master:\content\home\*' | New-ExplicitItemSource -Name 'Home Page' -InstallMode Overwrite
 $package.Sources.Add($source);
 
 # Save package


### PR DESCRIPTION
Modified the Get-Item call to correctly return the item and its children to match the example comment.

Without the wildcard, `New-ExplicitItemSource` does not implicitly add children items as stated in the "Detailed Description" section.